### PR TITLE
Emergency fix to handle items without attrib

### DIFF
--- a/lua/achaea/gmcp.lua
+++ b/lua/achaea/gmcp.lua
@@ -300,7 +300,7 @@ GMCPTrack["Char.Items.Add"] = function(message)
 	local attrib = itemToAdd.item.attrib
 	if itemToAdd.location == "room" then
 		oracle.items.room[itemToAdd.item.id] = itemToAdd.item
-		if string.match(attrib, "m") and not string.match(attrib, "x") and not string.match(attrib, "d") then
+		if type(attrib) == "string" and string.match(attrib, "m") and not string.match(attrib, "x") and not string.match(attrib, "d") then
 			mobs:add(itemToAdd.item)
 		end
 	end
@@ -313,7 +313,7 @@ GMCPTrack["Char.Items.Remove"] = function(message)
 	local attrib = itemToRemove.item.attrib
 	if itemToRemove.location == "room" then
 		oracle.items.room[itemToRemove.item.id] = nil
-		if string.match(attrib, "m") then
+		if type(attrib)=="string" and string.match(attrib, "m") then
 			mobs:remove(itemToRemove.item)
 		end
 	end


### PR DESCRIPTION
Added check that attrib tag is string (not nil) before applying string.matches.