### PR TITLE
Listener

### DIFF
--- a/lua/achaea/gmcp.lua
+++ b/lua/achaea/gmcp.lua
@@ -1,7 +1,6 @@
 require "json"
 require "luatable"
 
-
 oracle = oracle or {}
 -- Define gmcp tables --
 gmcp = {
@@ -74,6 +73,7 @@ GMCPDeepUpdate = function(t1,t2)
 end
 
 function handle_GMCP(name, line, wc)
+
 	local command = wc[1]
 	local args = wc[2]
 	GMCPTrackProcess(command,args)
@@ -458,17 +458,23 @@ GMCPTrack["Comm.Channel.List"] = function(message)
 end -- function
 
 GMCPTrack["Comm.Channel.Text"] = function(message)
+  
 	local data = json.decode(message)
 	local text = StripANSI(data.text)
-	if text:startswith("(") then return end -- if
 
-	local speaker = data.channel
+	local channel = data.channel
  
-	if string.find(speaker, "tell") then
-		speaker = "tells"
+	if string.find(channel, "tell") then
+		channel = "tells"
 	end -- if
-
-	AddToHistory(speaker, false, StripANSI(data.text))
+  
+  local talker = data.talker
+  
+  local comm = {text = text, talker = talker, channel = channel}
+  oracle.listener:call("Comm.Channel.Text", comm)
+  
+  if text:startswith("(") then return end -- if
+	AddToHistory(channel, false, StripANSI(data.text))
 end -- function
 
 GMCPTrack["IRE.Composer.Edit"] = function(message)

--- a/lua/achaea/gmcp.lua
+++ b/lua/achaea/gmcp.lua
@@ -381,6 +381,30 @@ GMCPTrack["Char.Items.Remove"] = function(message)
 	end -- if
 end -- function
 
+GMCPTrack["Room.Info"] = function(message)
+	local roomInfo = json.decode(message)
+	GMCPDeepUpdate(gmcp.Room.Info, roomInfo)
+	exits = {}
+	for k,v in pairs(roomInfo.exits) do
+		table.insert(exits, k)
+	end -- for
+end -- function
+
+GMCPTrack["Room.Players"] = function(message)
+	local players = json.decode(message)
+	GMCPDeepUpdate(gmcp.Room.Players, players)
+end -- function
+
+GMCPTrack["Room.AddPlayer"] = function(message)
+	local addPlayer = json.decode(message)
+	GMCPDeepUpdate(gmcp.Room.AddPlayer, addPlayer)
+end -- function
+
+GMCPTrack["Room.RemovePlayer"] = function(message)
+	local removePlayer = json.decode(message)
+	gmcp.Room.RemovePlayer = removePlayer
+end -- function
+
 GMCPTrack["IRE.Rift.List"] = function(message)
 	local riftItems = json.decode(message)
 	gmcp.IRE.Rift.List = riftItems
@@ -400,6 +424,11 @@ end -- function
 GMCPTrack["IRE.Target.Info"] = function(message)
 	local targetInfo = json.decode(message)
 	GMCPDeepUpdate(gmcp.IRE.Target.Info, targetInfo)
+end -- function
+
+GMCPTrack["Comm.Channel.List"] = function(message)
+	local channels = json.decode(message)
+	GMCPDeepUpdate(gmcp.Comm.Channel.List, channels)
 end -- function
 
 GMCPTrack["Comm.Channel.Text"] = function(message)

--- a/worlds/Achaea/oracle.lua
+++ b/worlds/Achaea/oracle.lua
@@ -92,7 +92,7 @@ end -- function
 --call returns true if it proceeds to the end and none of the functions called raised errors, false otherwise
 function oracle.listener:call(event, arg)
 	if type(event) ~= "string" then
-		return
+		return false
 	end --if
 	local t = self.callbacks[event]
 	local t2 = self.callbackonce[event]

--- a/worlds/Achaea/oracle.lua
+++ b/worlds/Achaea/oracle.lua
@@ -55,3 +55,81 @@ end -- function
 oracle.echo = function(what)
 	Note("[Oracle]: "..what)
 end -- function
+
+-- listener --
+oracle.listener = {}
+oracle.listener.callbacks = {}
+oracle.listener.callbackonce = {}
+
+--listener returns true if it proceeds to the end
+function oracle.listener:register(event, func, once)
+	local t
+	if type(event) ~= "string" or type(func) ~= "function" then
+		return
+	end -- if
+	if not once then
+		t = self.callbacks[event]
+	else
+		t = self.callbackonce[event]
+	end -- if
+	if not t or type(t) ~= "table" then
+		t = {}
+		if not once then
+			self.callbacks[event] = t
+		else
+			self.callbackonce[event] = t
+		end -- if
+	end -- if
+	for _,v in ipairs(t) do
+		if v == func then
+			return -- already registered
+		end -- if
+	end -- for
+	table.insert(t, func)
+	return true
+end -- function
+
+--call returns true if it proceeds to the end and none of the functions called raised errors, false otherwise
+function oracle.listener:call(event, arg)
+	if type(event) ~= "string" then
+		return
+	end --if
+	local t = self.callbacks[event]
+	local t2 = self.callbackonce[event]
+	local no_error = true
+	if type(t) == "table" and #t > 0 then
+		for i,v in ipairs(t) do
+			no_error = pcall(v,arg) and no_error
+		end	 -- for
+	end -- if
+	if type(t2) == "table" and #t2 > 0 then
+		ColourNote("red", "blue", event)
+		for i,v in ipairs(t2) do
+			no_error = pcall(v,arg) and no_error
+		end -- for
+	end -- if
+	self.callbackonce[event] = nil
+	return no_error
+end -- function
+
+--unregister returns true if func was found and removed, nil if invalid argumetns, false otherwise
+function oracle.listener:unregister(event, func, once)
+	if type(event) ~= "string" or type(func) ~= "function" then
+		return
+	end -- if
+	if not once then
+		local t = self.callbacks[event]
+	else
+		local t = self.callbackonce[event]
+	end -- if
+	if type(t) ~= "table" or #t == 0 then
+		return false
+	else
+		for i,v in ipairs(t) do
+			if v == func then
+				table.remove(t, i)
+				return true
+			end -- if
+		end -- for
+	end -- if
+end -- function


### PR DESCRIPTION
- Add listener functionality
- `oracle.listener` has `register`, `unregister`, and `call` methods
- `register(event, func, once)` tells the listener to add `func` to the list of functions to call upon receiving `event`
    - `once` is an optional argument indicating the function should be removed from the list once called
- Associate certain GMCP messages with events